### PR TITLE
npm run buildがOS X Yosemiteで落ちる問題

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ FL演習のオセロのあれ用のサーバーです。HTTPで提供される�
 1. `git clone https://github.com/uhyo/is-othello.git`で手元にコードをコピーします。
 2. [node.jsをインストール](http://nodejs.org/)します（`apt-get install nodejs`でも入りますが、なぜか`node`ではなく`nodejs`の名前で入るので自分でシンボリックリンクを貼る必要があります）。
 3. `is-othello`ディレクトリに入り`npm install`します（必要なモジュールがローカルにインストールされます）。
-4. `npm run build`を実行します。
+4. `npm run build`を実行します（Macで`glut default`が落ちる問題が確認されましたが、ファイルディスクリプタの上限数を超えている可能性があるため`ulimit -n 2560`とかやると通りました）。
 
 ## 使い方
 `npm start`でサーバーを起動します。TCPポート8080でHTTP、ポート3000でISOPのサーバーが起動します（デフォルトの場合）。


### PR DESCRIPTION
Mac OS X Yosemiteで確認された問題です。npm run buildをしようとすると

```
> is-othello@1.1.0 build /Users/levelfour/Documents/workspace/is/is-othello
> gulp default

[10:49:27] Using gulpfile ~/Documents/workspace/is/is-othello/gulpfile.js
[10:49:27] Starting 'jsx'...
[10:49:27] Starting 'tsc'...
[10:49:27] Starting 'sass'...
[10:49:27] Finished 'sass' after 247 ms
[10:49:29] Finished 'tsc' after 2.28 s

events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: EMFILE, open '/Users/levelfour/Documents/workspace/is/is-othello/node_modules/react/package.json'
```

となり怒られます。Macではデフォルトのファイルディスクリプタ上限数が256になっていてそれ以上ファイルを開けなくて落ちている模様なので、ulimitで上限数を変更すると直る可能性がある旨を追記しておきました。